### PR TITLE
fix(parser): do not parse shell commands if pipe

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -40,10 +40,18 @@ func parse(s string, channel *ChannelData, user *User) (*Cmd, error) {
 
 	if len(pieces) > 1 {
 		// get the arguments and remove extra spaces
+		var (
+			parsedArgs []string
+			err        error
+		)
 		c.RawArgs = strings.TrimSpace(pieces[1])
-		parsedArgs, err := shellwords.Parse(c.RawArgs)
-		if err != nil {
-			return nil, errors.New("Error parsing arguments: " + err.Error())
+		if strings.Contains(c.RawArgs, "|") {
+			parsedArgs = strings.Split(c.RawArgs, " ")
+		} else {
+			parsedArgs, err = shellwords.Parse(c.RawArgs)
+			if err != nil {
+				return nil, errors.New("Error parsing arguments: " + err.Error())
+			}
 		}
 		c.Args = parsedArgs
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -14,6 +14,7 @@ func TestParser(t *testing.T) {
 	cmdMixedCaseWithoutArgs := CmdPrefix + "Cmd"
 	cmdMixedCaseWithArgs := CmdPrefix + "Cmd    arg1  arg2   "
 	cmdMixedCaseWithQuotes := CmdPrefix + "Cmd    \"arg1  arg2\""
+	cmdMixedCaseWithPipeSymbol := CmdPrefix + "Cmd | arg1 | arg2"
 	cmdUnicode := CmdPrefix + "Çmd"
 
 	tests := []struct {
@@ -84,6 +85,17 @@ func TestParser(t *testing.T) {
 			RawArgs:     "\"arg1  arg2\"",
 			Args:        []string{"arg1  arg2"},
 			MessageData: &Message{Text: strings.TrimLeft("Cmd    \"arg1  arg2\"", CmdPrefix)},
+		}},
+		{cmdMixedCaseWithPipeSymbol, &Cmd{
+			Raw:         cmdMixedCaseWithPipeSymbol,
+			Command:     "cmd",
+			Channel:     channel.Channel,
+			ChannelData: channel,
+			User:        user,
+			Message:     "Cmd | arg1 | arg2",
+			RawArgs:     "| arg1 | arg2",
+			Args:        []string{"|", "arg1", "|", "arg2"},
+			MessageData: &Message{Text: strings.TrimLeft("Cmd | arg1 | arg2", CmdPrefix)},
 		}},
 		{cmdUnicode, &Cmd{
 			Raw:         cmdUnicode,


### PR DESCRIPTION
I've decided to use a simply way to fix this in order to don't break compatibility with existing code :cat2: 

If `|` is present in the command, the parser will ignore `shellwords.Parse`. In other terms, you won't be able to use stuffs like: 

```shell
$ some command | grep ${HOME}
```

`shellwords.Parse` will translate `${HOME}`